### PR TITLE
Add netstandard2.0 target framework +update dependencies

### DIFF
--- a/samples/DrawShapesWithImageSharp/DrawShapesWithImageSharp.csproj
+++ b/samples/DrawShapesWithImageSharp/DrawShapesWithImageSharp.csproj
@@ -15,8 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ImageSharp.Drawing" Version="1.0.0-alpha9-00189" />
-    <PackageReference Include="ImageSharp" Version="1.0.0-alpha9-00194" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0001" />
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/DrawShapesWithImageSharp/ImageSharpLogo.cs
+++ b/samples/DrawShapesWithImageSharp/ImageSharpLogo.cs
@@ -1,9 +1,7 @@
-﻿using ImageSharp;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Threading.Tasks;
+using SixLabors.ImageSharp;
 
 namespace SixLabors.Shapes.DrawShapesWithImageSharp
 {
@@ -14,7 +12,7 @@ namespace SixLabors.Shapes.DrawShapesWithImageSharp
             // the point are based on a 1206x1206 shape so size requires scaling from there
 
             float scalingFactor = size / 1206;
-            
+
             var center = new Vector2(603);
 
             // segment whoes cetner of rotation should be 
@@ -49,16 +47,16 @@ namespace SixLabors.Shapes.DrawShapesWithImageSharp
             var dimensions = (int)Math.Ceiling(size);
             using (var img = new Image<Rgba32>(dimensions, dimensions))
             {
-                img.Fill(Rgba32.Black);
-                img.Fill(Rgba32.FromHex("e1e1e1ff"), new SixLabors.Shapes.EllipsePolygon(center, 600f).Transform(scaler));
-                img.Fill(Rgba32.White, new SixLabors.Shapes.EllipsePolygon(center, 600f - 60).Transform(scaler));
+                img.Mutate(i => i.Fill(Rgba32.Black));
+                img.Mutate(i => i.Fill(Rgba32.FromHex("e1e1e1ff"), new EllipsePolygon(center, 600f).Transform(scaler)));
+                img.Mutate(i => i.Fill(Rgba32.White, new EllipsePolygon(center, 600f - 60).Transform(scaler)));
 
-                for (var i = 0; i < 6; i++)
+                for (var s = 0; s < 6; s++)
                 {
-                    img.Fill(colors[i], segments[i].Transform(scaler));
+                    img.Mutate(i => i.Fill(colors[s], segments[s].Transform(scaler)));
                 }
 
-                img.Fill(new Rgba32(0, 0, 0, 170), new ComplexPolygon(new SixLabors.Shapes.EllipsePolygon(center, 161f), new SixLabors.Shapes.EllipsePolygon(center, 61f)).Transform(scaler));
+                img.Mutate(i => i.Fill(new Rgba32(0, 0, 0, 170), new ComplexPolygon(new EllipsePolygon(center, 161f), new EllipsePolygon(center, 61f)).Transform(scaler)));
 
                 var fullPath = System.IO.Path.GetFullPath(System.IO.Path.Combine("Output", path));
 

--- a/samples/DrawShapesWithImageSharp/Program.cs
+++ b/samples/DrawShapesWithImageSharp/Program.cs
@@ -1,4 +1,4 @@
-﻿using ImageSharp;
+﻿using SixLabors.ImageSharp;
 using System;
 using System.IO;
 
@@ -206,12 +206,12 @@ namespace SixLabors.Shapes.DrawShapesWithImageSharp
 
             using (var img = new Image<Rgba32>(width, height))
             {
-                img.Fill(Rgba32.DarkBlue);
+                img.Mutate(i => i.Fill(Rgba32.DarkBlue));
 
                 foreach (var s in shape)
                 {
                     // In ImageSharp.Drawing.Paths there is an extension method that takes in an IShape directly.
-                    img.Fill(Rgba32.HotPink, s, new ImageSharp.GraphicsOptions(true));
+                    img.Mutate(i => i.Fill(Rgba32.HotPink, s, new GraphicsOptions(true)));
                 }
                 // img.Draw(Color.LawnGreen, 1, new ShapePath(shape));
 
@@ -232,13 +232,13 @@ namespace SixLabors.Shapes.DrawShapesWithImageSharp
 
             using (var img = new Image<Rgba32>(width, height))
             {
-                img.Fill(Rgba32.DarkBlue);
+                img.Mutate(i => i.Fill(Rgba32.DarkBlue));
 
                 // In ImageSharp.Drawing.Paths there is an extension method that takes in an IShape directly.
                 foreach (var s in shape)
                 {
                     // In ImageSharp.Drawing.Paths there is an extension method that takes in an IShape directly.
-                    img.Fill(Rgba32.HotPink, s, new ImageSharp.GraphicsOptions(true));
+                    img.Mutate(i => i.Fill(Rgba32.HotPink, s, new GraphicsOptions(true)));
                 }
 
                 // img.Draw(Color.LawnGreen, 1, new ShapePath(shape));

--- a/src/SixLabors.Shapes.Text/PathGlyphBuilder.cs
+++ b/src/SixLabors.Shapes.Text/PathGlyphBuilder.cs
@@ -18,6 +18,7 @@ namespace SixLabors.Shapes.Text
 
         private float yOffset = 0;
 
+        // TODO: Change to MathF on next release. AssemblyInfo.cs in Core did not list this project
         const float Pi = (float)Math.PI;
         const float HalfPi = Pi / 2f;
 

--- a/src/SixLabors.Shapes.Text/SixLabors.Shapes.Text.csproj
+++ b/src/SixLabors.Shapes.Text/SixLabors.Shapes.Text.csproj
@@ -5,8 +5,8 @@
     <AssemblyTitle>SixLabors.Shapes.Text</AssemblyTitle>
     <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
     <VersionPrefix Condition="$(packageversion) == ''">0.1.0-alpha1</VersionPrefix>
-    <Authors>Scott Williams and contributors</Authors>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <Authors>Six Labors and contributors</Authors>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SixLabors.Shapes.Text</AssemblyName>
@@ -34,7 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0002" />
+    <!--TODO: Add StyleCop; No time just now-->
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SixLabors.Shapes.Text/TextBuilder.cs
+++ b/src/SixLabors.Shapes.Text/TextBuilder.cs
@@ -14,7 +14,7 @@ namespace SixLabors.Shapes
     public static class TextBuilder
     {
         /// <summary>
-        /// Generates the shapes corresponding the glyphs described by the font and with the setting ing withing the FontSpan
+        /// Generates the shapes corresponding the glyphs described by the font and with the settings withing the FontSpan
         /// </summary>
         /// <param name="text">The text to generate glyphs for</param>
         /// <param name="location">The location</param>
@@ -32,7 +32,7 @@ namespace SixLabors.Shapes
         }
 
         /// <summary>
-        /// Generates the shapes corresponding the glyphs described by the font and with the setting ing withing the FontSpan
+        /// Generates the shapes corresponding the glyphs described by the font and with the settings withing the FontSpan
         /// </summary>
         /// <param name="text">The text to generate glyphs for</param>
         /// <param name="style">The style and settings to use while rendering the glyphs</param>

--- a/src/SixLabors.Shapes/SixLabors.Shapes.csproj
+++ b/src/SixLabors.Shapes/SixLabors.Shapes.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <Description>Polygon manipulation/merging and interrogation library. 
 
-Its a fully manged netstandard library so should work everywhere.</Description>
+It's a fully managed netstandard library so should work everywhere.</Description>
     <AssemblyTitle>SixLabors.Shapes</AssemblyTitle>
     <VersionPrefix Condition="$(packageversion) != ''">$(packageversion)</VersionPrefix>
     <VersionPrefix Condition="$(packageversion) == ''">0.1.0-alpha1</VersionPrefix>
-    <Authors>Scott Williams and contributors</Authors>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <Authors>Six Labors and contributors</Authors>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SixLabors.Shapes</AssemblyName>
@@ -35,8 +35,8 @@ Its a fully manged netstandard library so should work everywhere.</Description>
     <Compile Include="..\Shared\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0003" />
+      <!--TODO: Add StyleCop; No time just now-->
+    <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0004" />
     <PackageReference Include="System.Buffers" Version="4.4.0" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
As above.

I've noticed that StyleCop is not installed just now and I can't access any Core internals in Shapes.Text but that can both wait for the next release. 