### PR TITLE
Fix spelling of RectangularPolygon

### DIFF
--- a/samples/DrawShapesWithImageSharp/Program.cs
+++ b/samples/DrawShapesWithImageSharp/Program.cs
@@ -183,8 +183,8 @@ namespace SixLabors.Shapes.DrawShapesWithImageSharp
 
         private static void OutputClippedRectangle()
         {
-            var rect1 = new RectangularePolygon(10, 10, 40, 40);
-            var rect2 = new RectangularePolygon(20, 0, 20, 20);
+            var rect1 = new RectangularPolygon(10, 10, 40, 40);
+            var rect2 = new RectangularPolygon(20, 0, 20, 20);
             var paths = rect1.Clip(rect2);
 
             paths.SaveImage("Clipping", "RectangleWithTopClipped.png");

--- a/src/SixLabors.Shapes/RectangularPolygon.cs
+++ b/src/SixLabors.Shapes/RectangularPolygon.cs
@@ -12,7 +12,7 @@ namespace SixLabors.Shapes
     /// A way of optimizing drawing rectangles.
     /// </summary>
     /// <seealso cref="SixLabors.Shapes.IPath" />
-    public class RectangularePolygon : IPath, ISimplePath
+    public class RectangularPolygon : IPath, ISimplePath
     {
         private readonly Vector2 topLeft;
         private readonly Vector2 bottomRight;
@@ -22,23 +22,23 @@ namespace SixLabors.Shapes
         private readonly RectangleF bounds;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RectangularePolygon" /> class.
+        /// Initializes a new instance of the <see cref="RectangularPolygon" /> class.
         /// </summary>
         /// <param name="x">The x.</param>
         /// <param name="y">The y.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        public RectangularePolygon(float x, float y, float width, float height)
+        public RectangularPolygon(float x, float y, float width, float height)
             : this(new PointF(x, y), new SizeF(width, height))
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RectangularePolygon" /> class.
+        /// Initializes a new instance of the <see cref="RectangularPolygon" /> class.
         /// </summary>
         /// <param name="topLeft">The top left.</param>
         /// <param name="bottomRight">The bottom right.</param>
-        public RectangularePolygon(PointF topLeft, PointF bottomRight)
+        public RectangularPolygon(PointF topLeft, PointF bottomRight)
         {
             this.Location = topLeft;
             this.topLeft = topLeft;
@@ -59,20 +59,20 @@ namespace SixLabors.Shapes
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RectangularePolygon"/> class.
+        /// Initializes a new instance of the <see cref="RectangularPolygon"/> class.
         /// </summary>
         /// <param name="location">The location.</param>
         /// <param name="size">The size.</param>
-        public RectangularePolygon(PointF location, SizeF size)
+        public RectangularPolygon(PointF location, SizeF size)
             : this(location, location + size)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RectangularePolygon"/> class.
+        /// Initializes a new instance of the <see cref="RectangularPolygon"/> class.
         /// </summary>
         /// <param name="rectangle">The rectangle.</param>
-        public RectangularePolygon(RectangleF rectangle)
+        public RectangularPolygon(RectangleF rectangle)
             : this(rectangle.Location, rectangle.Location + rectangle.Size)
         {
         }
@@ -201,7 +201,7 @@ namespace SixLabors.Shapes
 
         /// <summary>
         /// Determines if the specified point is contained within the rectangular region defined by
-        /// this <see cref="RectangularePolygon" />.
+        /// this <see cref="RectangularPolygon" />.
         /// </summary>
         /// <param name="point">The point.</param>
         /// <returns>
@@ -214,7 +214,7 @@ namespace SixLabors.Shapes
 
         /// <summary>
         /// Based on a line described by <paramref name="start"/> and <paramref name="end"/>
-        /// populate a buffer for all points on the edges of the <see cref="RectangularePolygon"/>
+        /// populate a buffer for all points on the edges of the <see cref="RectangularPolygon"/>
         /// that the line intersects.
         /// </summary>
         /// <param name="start">The start point of the line.</param>

--- a/tests/SixLabors.Shapes.Tests/Extensions.cs
+++ b/tests/SixLabors.Shapes.Tests/Extensions.cs
@@ -7,7 +7,7 @@ namespace SixLabors.Shapes.Tests
 {
     public static class Extensions
     {
-        public static IPath AsPath(this RectangularePolygon rect)
+        public static IPath AsPath(this RectangularPolygon rect)
         {
             return ((IPath)rect);
         }

--- a/tests/SixLabors.Shapes.Tests/GeneralPolygonIntersectionTests.cs
+++ b/tests/SixLabors.Shapes.Tests/GeneralPolygonIntersectionTests.cs
@@ -30,7 +30,7 @@ namespace SixLabors.Shapes.Tests
             { "scaled_300_iris_5", Shapes.IrisSegment(300, 5) },
             { "scaled_300_iris_6", Shapes.IrisSegment(300, 6) },
 
-            { "clippedRect",   new RectangularePolygon(10, 10, 40, 40).Clip(new RectangularePolygon(20, 0, 20, 20))     },
+            { "clippedRect",   new RectangularPolygon(10, 10, 40, 40).Clip(new RectangularPolygon(20, 0, 20, 20))     },
 
             { "hourGlass", Shapes.HourGlass().AsClosedPath() },
             { "BigCurve", new Polygon(new CubicBezierLineSegment( new Vector2(10, 400), new Vector2(30, 10), new Vector2(240, 30), new Vector2(300, 400))) },

--- a/tests/SixLabors.Shapes.Tests/PolygonClipper/ClipperTests.cs
+++ b/tests/SixLabors.Shapes.Tests/PolygonClipper/ClipperTests.cs
@@ -18,11 +18,11 @@ namespace SixLabors.Shapes.Tests.PolygonClipper
 
     public class ClipperTests
     {
-        private RectangularePolygon BigSquare = new RectangularePolygon(10, 10, 40, 40);
-        private RectangularePolygon Hole = new RectangularePolygon(20, 20, 10, 10);
-        private RectangularePolygon TopLeft = new RectangularePolygon(0, 0, 20, 20);
-        private RectangularePolygon TopRight = new RectangularePolygon(30, 0, 20, 20);
-        private RectangularePolygon TopMiddle = new RectangularePolygon(20, 0, 10, 20);
+        private RectangularPolygon BigSquare = new RectangularPolygon(10, 10, 40, 40);
+        private RectangularPolygon Hole = new RectangularPolygon(20, 20, 10, 10);
+        private RectangularPolygon TopLeft = new RectangularPolygon(0, 0, 20, 20);
+        private RectangularPolygon TopRight = new RectangularPolygon(30, 0, 20, 20);
+        private RectangularPolygon TopMiddle = new RectangularPolygon(20, 0, 10, 20);
 
         private Polygon BigTriangle = new Polygon(new LinearLineSegment(
                          new Vector2(10, 10),
@@ -102,7 +102,7 @@ namespace SixLabors.Shapes.Tests.PolygonClipper
         [Fact]
         public void ClippingRectanglesCreateCorrectNumberOfPoints()
         {
-            IEnumerable<ISimplePath> paths = new RectangularePolygon(10, 10, 40, 40).Clip(new RectangularePolygon(20, 0, 20, 20)).Flatten();
+            IEnumerable<ISimplePath> paths = new RectangularPolygon(10, 10, 40, 40).Clip(new RectangularPolygon(20, 0, 20, 20)).Flatten();
             Assert.Equal(1, paths.Count());
             var points = paths.First().Points;
 

--- a/tests/SixLabors.Shapes.Tests/PolygonTests.cs
+++ b/tests/SixLabors.Shapes.Tests/PolygonTests.cs
@@ -232,7 +232,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void ClippingEdgefromInside()
         {
-            IPath simplePath = new RectangularePolygon(10, 10, 100, 100).Clip(new RectangularePolygon(20, 0, 20, 20));
+            IPath simplePath = new RectangularPolygon(10, 10, 100, 100).Clip(new RectangularPolygon(20, 0, 20, 20));
 
             IEnumerable<PointF> intersections = simplePath.FindIntersections(new PointF(float.MinValue, 20), new PointF(float.MaxValue, 20));
 

--- a/tests/SixLabors.Shapes.Tests/RectangleTests.cs
+++ b/tests/SixLabors.Shapes.Tests/RectangleTests.cs
@@ -104,7 +104,7 @@ namespace SixLabors.Shapes.Tests
         [MemberData(nameof(PointInPolygonTheoryData))]
         public void PointInPolygon(TestPoint location, TestSize size, TestPoint point, bool isInside)
         {
-            RectangularePolygon shape = new RectangularePolygon(location, size);
+            RectangularPolygon shape = new RectangularPolygon(location, size);
             Assert.Equal(isInside, shape.Contains(point));
         }
 
@@ -112,7 +112,7 @@ namespace SixLabors.Shapes.Tests
         [MemberData(nameof(DistanceTheoryData))]
         public void Distance(TestPoint location, TestSize size, TestPoint point, float expectecDistance)
         {
-            IPath shape = new RectangularePolygon(location, size);
+            IPath shape = new RectangularPolygon(location, size);
 
             Assert.Equal(expectecDistance, shape.Distance(point).DistanceFromPath);
         }
@@ -121,7 +121,7 @@ namespace SixLabors.Shapes.Tests
         [MemberData(nameof(PathDistanceTheoryData))]
         public void DistanceFromPath_Path(TestPoint point, float expectecDistance, float alongPath)
         {
-            IPath shape = new RectangularePolygon(0, 0, 10, 10).AsPath();
+            IPath shape = new RectangularPolygon(0, 0, 10, 10).AsPath();
             PointInfo info = shape.Distance(point);
             Assert.Equal(expectecDistance, info.DistanceFromPath);
             Assert.Equal(alongPath, info.DistanceAlongPath);
@@ -130,35 +130,35 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Left()
         {
-            RectangularePolygon shape = new RectangularePolygon(10, 11, 12, 13);
+            RectangularPolygon shape = new RectangularPolygon(10, 11, 12, 13);
             Assert.Equal(10, shape.Left);
         }
 
         [Fact]
         public void Right()
         {
-            RectangularePolygon shape = new RectangularePolygon(10, 11, 12, 13);
+            RectangularPolygon shape = new RectangularPolygon(10, 11, 12, 13);
             Assert.Equal(22, shape.Right);
         }
 
         [Fact]
         public void Top()
         {
-            RectangularePolygon shape = new RectangularePolygon(10, 11, 12, 13);
+            RectangularPolygon shape = new RectangularPolygon(10, 11, 12, 13);
             Assert.Equal(11, shape.Top);
         }
 
         [Fact]
         public void Bottom()
         {
-            RectangularePolygon shape = new RectangularePolygon(10, 11, 12, 13);
+            RectangularPolygon shape = new RectangularPolygon(10, 11, 12, 13);
             Assert.Equal(24, shape.Bottom);
         }
 
         [Fact]
         public void SizeF()
         {
-            RectangularePolygon shape = new RectangularePolygon(10, 11, 12, 13);
+            RectangularPolygon shape = new RectangularPolygon(10, 11, 12, 13);
             Assert.Equal(12, shape.Size.Width);
             Assert.Equal(13, shape.Size.Height);
         }
@@ -166,7 +166,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Bounds_Shape()
         {
-            IPath shape = new RectangularePolygon(10, 11, 12, 13);
+            IPath shape = new RectangularPolygon(10, 11, 12, 13);
             Assert.Equal(10, shape.Bounds.Left);
             Assert.Equal(22, shape.Bounds.Right);
             Assert.Equal(11, shape.Bounds.Top);
@@ -176,7 +176,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void LienearSegements()
         {
-            IPath shape = new RectangularePolygon(10, 11, 12, 13).AsPath();
+            IPath shape = new RectangularPolygon(10, 11, 12, 13).AsPath();
             var segemnts = shape.Flatten().ToArray()[0].Points;
             Assert.Equal(new PointF(10, 11), segemnts[0]);
             Assert.Equal(new PointF(22, 11), segemnts[1]);
@@ -187,7 +187,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Intersections_2()
         {
-            IPath shape = new RectangularePolygon(1, 1, 10, 10);
+            IPath shape = new RectangularPolygon(1, 1, 10, 10);
             IEnumerable<PointF> intersections = shape.FindIntersections(new PointF(0, 5), new PointF(20, 5));
 
             Assert.Equal(2, intersections.Count());
@@ -198,7 +198,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Intersections_1()
         {
-            IPath shape = new RectangularePolygon(1, 1, 10, 10);
+            IPath shape = new RectangularPolygon(1, 1, 10, 10);
             IEnumerable<PointF> intersections = shape.FindIntersections(new PointF(0, 5), new PointF(5, 5));
 
             Assert.Equal(1, intersections.Count());
@@ -208,7 +208,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Intersections_0()
         {
-            IPath shape = new RectangularePolygon(1, 1, 10, 10);
+            IPath shape = new RectangularPolygon(1, 1, 10, 10);
             IEnumerable<PointF> intersections = shape.FindIntersections(new PointF(0, 5), new PointF(-5, 5));
 
             Assert.Equal(0, intersections.Count());
@@ -217,7 +217,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Bounds_Path()
         {
-            IPath shape = new RectangularePolygon(10, 11, 12, 13).AsPath();
+            IPath shape = new RectangularPolygon(10, 11, 12, 13).AsPath();
             Assert.Equal(10, shape.Bounds.Left);
             Assert.Equal(22, shape.Bounds.Right);
             Assert.Equal(11, shape.Bounds.Top);
@@ -227,14 +227,14 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void MaxIntersections_Shape()
         {
-            IPath shape = new RectangularePolygon(10, 11, 12, 13);
+            IPath shape = new RectangularPolygon(10, 11, 12, 13);
             Assert.Equal(4, shape.MaxIntersections);
         }
 
         [Fact]
         public void ShapePaths()
         {
-            IPath shape = new RectangularePolygon(10, 11, 12, 13);
+            IPath shape = new RectangularPolygon(10, 11, 12, 13);
 
             Assert.Equal(shape, shape.AsClosedPath());
         }
@@ -243,7 +243,7 @@ namespace SixLabors.Shapes.Tests
         public void TransformIdnetityReturnsSahpeObject()
         {
 
-            IPath shape = new RectangularePolygon(0, 0, 200, 60);
+            IPath shape = new RectangularPolygon(0, 0, 200, 60);
             IPath transformdShape =  shape.Transform(Matrix3x2.Identity);
 
             Assert.Same(shape, transformdShape);
@@ -252,7 +252,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Transform()
         {
-            IPath shape = new RectangularePolygon(0, 0, 200, 60);
+            IPath shape = new RectangularPolygon(0, 0, 200, 60);
 
             IPath newShape = shape.Transform(new Matrix3x2(0, 1, 1, 0, 20, 2));
 
@@ -263,7 +263,7 @@ namespace SixLabors.Shapes.Tests
         [Fact]
         public void Center()
         {
-            RectangularePolygon shape = new RectangularePolygon(50, 50, 200, 60);
+            RectangularPolygon shape = new RectangularPolygon(50, 50, 200, 60);
 
             Assert.Equal(new PointF(150, 80), shape.Center);
         }
@@ -280,7 +280,7 @@ namespace SixLabors.Shapes.Tests
         [InlineData(620, 150, 50, Pi)] // wrap about end of path
         public void PointOnPath(float distance, float expectedX, float expectedY, float expectedAngle)
         {
-            IPath shape = new RectangularePolygon(50, 50, 200, 60);
+            IPath shape = new RectangularPolygon(50, 50, 200, 60);
             var point = shape.PointAlongPath(distance);
             Assert.Equal(expectedX, point.Point.X);
             Assert.Equal(expectedY, point.Point.Y);


### PR DESCRIPTION
- Fixes spelling of `RectangularePolygon` to `RectangularPolygon`