### PR TITLE
Fix shape cut off, used to return the whole shape

### DIFF
--- a/src/SixLabors.Shapes/PolygonClipper/Clipper.cs
+++ b/src/SixLabors.Shapes/PolygonClipper/Clipper.cs
@@ -63,34 +63,24 @@ namespace SixLabors.Shapes.PolygonClipper
             IPath[] shapes = new IPath[results.Count];
             for (int i = 0; i < results.Count; i++)
             {
-                object source = results[i].Source;
-                IPath path = source as IPath;
-
-                if (path != null)
+                PointF[] points = new PointF[results[i].Contour.Count];
+                for (int j = 0; j < results[i].Contour.Count; j++)
                 {
-                    shapes[i] = path;
+                    IntPoint p = results[i].Contour[j];
+
+                    // to make the floating point polygons compatable with clipper we had
+                    // to scale them up to make them ints but still retain some level of precision
+                    // thus we have to scale them back down
+                    points[j] = new Vector2(p.X / ScalingFactor, p.Y / ScalingFactor);
+                }
+
+                if (results[i].IsOpen)
+                {
+                    shapes[i] = new Path(new LinearLineSegment(points));
                 }
                 else
                 {
-                    PointF[] points = new PointF[results[i].Contour.Count];
-                    for (int j = 0; j < results[i].Contour.Count; j++)
-                    {
-                        IntPoint p = results[i].Contour[j];
-
-                        // to make the floating point polygons compatable with clipper we had
-                        // to scale them up to make them ints but still retain some level of precision
-                        // thus we have to scale them back down
-                        points[j] = new Vector2(p.X / ScalingFactor, p.Y / ScalingFactor);
-                    }
-
-                    if (results[i].IsOpen)
-                    {
-                        shapes[i] = new Path(new LinearLineSegment(points));
-                    }
-                    else
-                    {
-                        shapes[i] = new Polygon(new LinearLineSegment(points));
-                    }
+                    shapes[i] = new Polygon(new LinearLineSegment(points));
                 }
             }
 
@@ -157,7 +147,7 @@ namespace SixLabors.Shapes.PolygonClipper
             PolyType type = clippingType == ClippingType.Clip ? PolyType.ptClip : PolyType.ptSubject;
             lock (this.syncRoot)
             {
-                this.innerClipper.AddPath(points, type, path.IsClosed, path);
+                this.innerClipper.AddPath(points, type, path.IsClosed);
             }
         }
     }

--- a/src/SixLabors.Shapes/RectangularPolygon.cs
+++ b/src/SixLabors.Shapes/RectangularPolygon.cs
@@ -200,6 +200,15 @@ namespace SixLabors.Shapes
         public PointF Center => (this.topLeft + this.bottomRight) / 2;
 
         /// <summary>
+        /// Converts the polygon to a rectangular polygon from its bounds.
+        /// </summary>
+        /// <param name="polygon">The polygon to convert.</param>
+        public static explicit operator RectangularPolygon(Polygon polygon)
+        {
+            return new RectangularPolygon(polygon.Bounds.X, polygon.Bounds.Y, polygon.Bounds.Width, polygon.Bounds.Height);
+        }
+
+        /// <summary>
         /// Determines if the specified point is contained within the rectangular region defined by
         /// this <see cref="RectangularPolygon" />.
         /// </summary>
@@ -445,6 +454,40 @@ namespace SixLabors.Shapes
         IPath IPath.AsClosedPath()
         {
             return this;
+        }
+
+        /// <summary>
+        /// Equality comparer for two RectangularPolygons
+        /// </summary>
+        /// <param name="obj">The polygon to compare to.</param>
+        /// <returns>Returns a value indicating if the rectangles are equal.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj == null || this.GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var otherRectangle = (RectangularPolygon)obj;
+
+            return this.X == otherRectangle.X &&
+                this.Y == otherRectangle.Y &&
+                this.Height == otherRectangle.Height &&
+                this.Width == otherRectangle.Width;
+        }
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            var hashCode = -1073544145;
+            hashCode = (hashCode * -1521134295) + this.X.GetHashCode();
+            hashCode = (hashCode * -1521134295) + this.Y.GetHashCode();
+            hashCode = (hashCode * -1521134295) + this.Width.GetHashCode();
+            hashCode = (hashCode * -1521134295) + this.Height.GetHashCode();
+            return hashCode;
         }
     }
 }

--- a/tests/SixLabors.Shapes.Tests/PolygonClipper/ClipperTests.cs
+++ b/tests/SixLabors.Shapes.Tests/PolygonClipper/ClipperTests.cs
@@ -51,6 +51,25 @@ namespace SixLabors.Shapes.Tests.PolygonClipper
         }
 
         [Fact]
+        public void OverlappingTriangleCutRightSide()
+        {
+            var triangle = new Polygon(new LinearLineSegment(
+                new Vector2(0, 50),
+                new Vector2(70, 0),
+                new Vector2(50, 100)));
+
+            var cutout = new Polygon(new LinearLineSegment(
+                new Vector2(20, 0),
+                new Vector2(70, 0),
+                new Vector2(70, 100),
+                new Vector2(20, 100)));
+
+            var shapes = this.Clip(triangle, cutout);
+            Assert.Equal(1, shapes.Count());
+            Assert.DoesNotContain(triangle, shapes);
+        }
+
+        [Fact]
         public void OverlappingTriangles()
         {
             var shapes = this.Clip(this.BigTriangle, this.LittleTriangle);
@@ -66,9 +85,12 @@ namespace SixLabors.Shapes.Tests.PolygonClipper
         [Fact]
         public void NonOverlapping()
         {
-            var shapes = this.Clip(this.TopLeft, this.TopRight);
+            var shapes = this.Clip(this.TopLeft, this.TopRight)
+                .OfType<Polygon>().Select(x => (RectangularPolygon)x);
+
             Assert.Equal(1, shapes.Count());
             Assert.Contains(this.TopLeft, shapes);
+
             Assert.DoesNotContain(this.TopRight, shapes);
         }
 
@@ -76,6 +98,7 @@ namespace SixLabors.Shapes.Tests.PolygonClipper
         public void OverLappingReturns1NewShape()
         {
             var shapes = this.Clip(this.BigSquare, this.TopLeft);
+
             Assert.Equal(1, shapes.Count());
             Assert.DoesNotContain(this.BigSquare, shapes);
             Assert.DoesNotContain(this.TopLeft, shapes);
@@ -84,7 +107,9 @@ namespace SixLabors.Shapes.Tests.PolygonClipper
         [Fact]
         public void OverlappingButNotCrossingRetuensOrigionalShapes()
         {
-            var shapes = this.Clip(this.BigSquare, this.Hole);
+            var shapes = this.Clip(this.BigSquare, this.Hole)
+                .OfType<Polygon>().Select(x => (RectangularPolygon)x);
+
             Assert.Equal(2, shapes.Count());
             Assert.Contains(this.BigSquare, shapes);
             Assert.Contains(this.Hole, shapes);


### PR DESCRIPTION
The new test `OverlappingTriangleCutRightSide` fails with the current clipping implementation, it returns the unclipped shape