### PR TITLE
Add an IPath.FindIntersections() overload consuming Span<PointF>

### DIFF
--- a/src/SixLabors.Shapes/ComplexPolygon.cs
+++ b/src/SixLabors.Shapes/ComplexPolygon.cs
@@ -164,10 +164,18 @@ namespace SixLabors.Shapes
         /// </returns>
         public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
+            Span<PointF> subBuffer = buffer.AsSpan(offset);
+            return this.FindIntersections(start, end, subBuffer);
+        }
+
+        /// <inheritdoc />
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
+        {
             int totalAdded = 0;
             for (int i = 0; i < this.paths.Length; i++)
             {
-                int added = this.paths[i].FindIntersections(start, end, buffer, totalAdded + offset);
+                Span<PointF> subBuffer = buffer.Slice(totalAdded);
+                int added = this.paths[i].FindIntersections(start, end, subBuffer);
                 totalAdded += added;
             }
 

--- a/src/SixLabors.Shapes/EllipsePolygon.cs
+++ b/src/SixLabors.Shapes/EllipsePolygon.cs
@@ -7,6 +7,8 @@ using SixLabors.Primitives;
 
 namespace SixLabors.Shapes
 {
+    using System;
+
     /// <summary>
     /// A shape made up of a single path made up of one of more <see cref="ILineSegment"/>s
     /// </summary>
@@ -152,7 +154,14 @@ namespace SixLabors.Shapes
         /// <inheritdoc/>
         int IPath.FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
-            return this.innerPath.FindIntersections(start, end, buffer, offset);
+            Span<PointF> subBuffer = buffer.AsSpan(offset);
+            return this.innerPath.FindIntersections(start, end, subBuffer);
+        }
+
+        /// <inheritdoc/>
+        int IPath.FindIntersections(PointF start, PointF end, Span<PointF> buffer)
+        {
+            return this.innerPath.FindIntersections(start, end, buffer);
         }
 
         /// <summary>

--- a/src/SixLabors.Shapes/EllipsePolygon.cs
+++ b/src/SixLabors.Shapes/EllipsePolygon.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using SixLabors.Primitives;
 
 namespace SixLabors.Shapes
 {
-    using System;
-
     /// <summary>
     /// A shape made up of a single path made up of one of more <see cref="ILineSegment"/>s
     /// </summary>

--- a/src/SixLabors.Shapes/IPath.cs
+++ b/src/SixLabors.Shapes/IPath.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using SixLabors.Primitives;
@@ -68,6 +69,18 @@ namespace SixLabors.Shapes
         /// The number of intersections populated into the buffer.
         /// </returns>
         int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset);
+
+        /// <summary>
+        /// Based on a line described by <paramref name="start"/> and <paramref name="end"/>
+        /// populate a buffer for all points on the polygon that the line intersects.
+        /// </summary>
+        /// <param name="start">The start point of the line.</param>
+        /// <param name="end">The end point of the line.</param>
+        /// <param name="buffer">The buffer that will be populated with intersections.</param>
+        /// <returns>
+        /// The number of intersections populated into the buffer.
+        /// </returns>
+        int FindIntersections(PointF start, PointF end, Span<PointF> buffer);
 
         /// <summary>
         /// Determines whether the <see cref="IPath"/> contains the specified point

--- a/src/SixLabors.Shapes/InternalPath.cs
+++ b/src/SixLabors.Shapes/InternalPath.cs
@@ -179,9 +179,8 @@ namespace SixLabors.Shapes
         /// <param name="start">The start.</param>
         /// <param name="end">The end.</param>
         /// <param name="buffer">The buffer.</param>
-        /// <param name="offset">The offset.</param>
         /// <returns>number of intersections hit</returns>
-        public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
         {
             if (this.points.Length < 2)
             {
@@ -310,7 +309,7 @@ namespace SixLabors.Shapes
                             }
 
                             // we are not double crossing so just add it once
-                            buffer[position + offset] = point;
+                            buffer[position] = point;
                             position++;
                             count--;
                         }
@@ -353,7 +352,7 @@ namespace SixLabors.Shapes
             PointF[] buffer = ArrayPool<PointF>.Shared.Rent(this.points.Length);
             try
             {
-                int intersection = this.FindIntersections(point, new Vector2(this.Bounds.Left - 1, this.Bounds.Top - 1), buffer, 0);
+                int intersection = this.FindIntersections(point, new Vector2(this.Bounds.Left - 1, this.Bounds.Top - 1), buffer);
                 if ((intersection & 1) == 1)
                 {
                     return true;

--- a/src/SixLabors.Shapes/Path.cs
+++ b/src/SixLabors.Shapes/Path.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -165,7 +166,14 @@ namespace SixLabors.Shapes
         /// </returns>
         public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
-            return this.InnerPath.FindIntersections(start, end, buffer, offset);
+            Span<PointF> subBuffer = buffer.AsSpan(offset);
+            return this.InnerPath.FindIntersections(start, end, subBuffer);
+        }
+
+        /// <inheritdoc />
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
+        {
+            return this.InnerPath.FindIntersections(start, end, buffer);
         }
 
         /// <summary>

--- a/src/SixLabors.Shapes/RectangularPolygon.cs
+++ b/src/SixLabors.Shapes/RectangularPolygon.cs
@@ -235,6 +235,14 @@ namespace SixLabors.Shapes
         /// </returns>
         public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
+            Span<PointF> subBuffer = buffer.AsSpan(offset);
+            return this.FindIntersections(start, end, subBuffer);
+        }
+
+        /// <inheritdoc />
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
+        {
+            int offset = 0;
             int discovered = 0;
             Vector2 startPoint = Vector2.Clamp(start, this.topLeft, this.bottomRight);
             Vector2 endPoint = Vector2.Clamp(end, this.topLeft, this.bottomRight);
@@ -263,6 +271,7 @@ namespace SixLabors.Shapes
 
             return discovered;
         }
+
 
         /// <summary>
         /// Transforms the rectangle using specified matrix.

--- a/src/SixLabors.Shapes/RectangularPolygon.cs
+++ b/src/SixLabors.Shapes/RectangularPolygon.cs
@@ -272,7 +272,6 @@ namespace SixLabors.Shapes
             return discovered;
         }
 
-
         /// <summary>
         /// Transforms the rectangle using specified matrix.
         /// </summary>

--- a/src/SixLabors.Shapes/SixLabors.Shapes.csproj
+++ b/src/SixLabors.Shapes/SixLabors.Shapes.csproj
@@ -49,5 +49,6 @@
         </PackageReference>
         <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0005" />
         <PackageReference Include="System.Buffers" Version="4.4.0" />
+        <PackageReference Include="System.Memory" Version="4.5.0-rc1" />
     </ItemGroup>
 </Project>

--- a/tests/SixLabors.Shapes.Tests/InternalPathTests.cs
+++ b/tests/SixLabors.Shapes.Tests/InternalPathTests.cs
@@ -179,7 +179,7 @@ namespace SixLabors.Shapes.Tests
         {
             InternalPath shape = Create(new PointF(0, 0), new Size(10, 10));
             PointF[] buffer = new PointF[shape.PointCount];
-            int hits = shape.FindIntersections(new PointF(5, -10), new PointF(5, 20), buffer, 0);
+            int hits = shape.FindIntersections(new PointF(5, -10), new PointF(5, 20), buffer);
 
             Assert.Equal(2, hits);
             Assert.Equal(new PointF(5, 0), buffer[0]);

--- a/tests/SixLabors.Shapes.Tests/PathExtensions.cs
+++ b/tests/SixLabors.Shapes.Tests/PathExtensions.cs
@@ -6,16 +6,13 @@
 namespace SixLabors.Shapes
 {
     using SixLabors.Primitives;
-    using System;
+
     using System.Buffers;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Numerics;
-    using System.Threading.Tasks;
 
     internal static class InternalPathExtensions
     {
-
         /// <summary>
         /// Finds the intersections.
         /// </summary>
@@ -28,7 +25,7 @@ namespace SixLabors.Shapes
             PointF[] buffer = ArrayPool<PointF>.Shared.Rent(path.PointCount);
             try
             {
-                int hits = path.FindIntersections(start, end, buffer, 0);
+                int hits = path.FindIntersections(start, end, buffer);
                 for (int i = 0; i < hits; i++)
                 {
                     results.Add(buffer[i]);

--- a/tests/SixLabors.Shapes.Tests/SixLabors.Shapes.Tests.csproj
+++ b/tests/SixLabors.Shapes.Tests/SixLabors.Shapes.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="System.Memory" Version="4.5.0-rc1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Moq" Version="4.7.99" />


### PR DESCRIPTION
## Problem
`ShapeRegion.Scan()` should work with `IBuffer<T>` [instead of allocating an array](https://github.com/SixLabors/ImageSharp/blob/master/src/ImageSharp.Drawing/Primitives/ShapeRegion.cs#L48). For that we need a an overload of `FindIntersections()` that consumes a `Span<PointF>`.

## Solution
- Add reference to the `System.Memory` RC1 package
- Introduce the overload
- Keep the `(PointF[] buffer, int offset)` overload to preserve binary compatibility