### PR TITLE
Update package references + fix issues

### DIFF
--- a/src/SixLabors.Shapes.Text/BaseGlyphBuilder.cs
+++ b/src/SixLabors.Shapes.Text/BaseGlyphBuilder.cs
@@ -50,10 +50,10 @@ namespace SixLabors.Shapes.Text
         }
 
         /// <inheritdoc/>
-        bool IGlyphRenderer.BeginGlyph(RectangleF rect, int hashCode)
+        bool IGlyphRenderer.BeginGlyph(RectangleF bounds, GlyphRendererParameters paramaters)
         {
             this.builder.Clear();
-            this.BeginGlyph(rect);
+            this.BeginGlyph(bounds);
             return true;
         }
 

--- a/src/SixLabors.Shapes.Text/SixLabors.Shapes.Text.csproj
+++ b/src/SixLabors.Shapes.Text/SixLabors.Shapes.Text.csproj
@@ -41,7 +41,7 @@
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0006" />
+        <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0007" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SixLabors.Shapes/SixLabors.Shapes.csproj
+++ b/src/SixLabors.Shapes/SixLabors.Shapes.csproj
@@ -47,8 +47,6 @@
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
             <PrivateAssets>All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0005" />
-        <PackageReference Include="System.Buffers" Version="4.5.0" />
-        <PackageReference Include="System.Memory" Version="4.5.0" />
+        <PackageReference Include="SixLabors.Core" Version="1.0.0-beta0006" />
     </ItemGroup>
 </Project>

--- a/tests/SixLabors.Shapes.Tests/SixLabors.Shapes.Tests.csproj
+++ b/tests/SixLabors.Shapes.Tests/SixLabors.Shapes.Tests.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="System.Memory" Version="4.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Moq" Version="4.8.2" />


### PR DESCRIPTION
- Update packages: `SixLabors.Core -> 1.0.0-beta006` and `SixLabors.Fonts- 1.0.0-beta007`
- Reference `System.Memory` and `System.Buffers` indirectly through SL.Core -> remove direct references
- Fix `IGlyphRenderer.BeginGlyph()` in `BaseGlyphRenderer`