### PR TITLE
Improve CQ

### DIFF
--- a/samples/DrawShapesWithImageSharp/DrawShapesWithImageSharp.csproj
+++ b/samples/DrawShapesWithImageSharp/DrawShapesWithImageSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/SixLabors.Shapes/ComplexPolygon.cs
+++ b/src/SixLabors.Shapes/ComplexPolygon.cs
@@ -12,7 +12,7 @@ namespace SixLabors.Shapes
     /// <summary>
     /// Represents a complex polygon made up of one or more shapes overlayed on each other, where overlaps causes holes.
     /// </summary>
-    /// <seealso cref="SixLabors.Shapes.IPath" />
+    /// <seealso cref="IPath" />
     public sealed class ComplexPolygon : IPath
     {
         private readonly IPath[] paths;
@@ -122,7 +122,7 @@ namespace SixLabors.Shapes
         public PointInfo Distance(PointF point)
         {
             float dist = float.MaxValue;
-            PointInfo pointInfo = default(PointInfo);
+            PointInfo pointInfo = default;
             bool inside = false;
             foreach (IPath shape in this.Paths)
             {
@@ -219,7 +219,7 @@ namespace SixLabors.Shapes
                 return this;
             }
 
-            IPath[] shapes = new IPath[this.paths.Length];
+            var shapes = new IPath[this.paths.Length];
             int i = 0;
             foreach (IPath s in this.Paths)
             {
@@ -237,7 +237,7 @@ namespace SixLabors.Shapes
         /// </returns>
         public IEnumerable<ISimplePath> Flatten()
         {
-            List<ISimplePath> paths = new List<ISimplePath>();
+            var paths = new List<ISimplePath>();
             foreach (IPath path in this.Paths)
             {
                 paths.AddRange(path.Flatten());
@@ -260,7 +260,7 @@ namespace SixLabors.Shapes
             }
             else
             {
-                IPath[] paths = new IPath[this.paths.Length];
+                var paths = new IPath[this.paths.Length];
                 for (int i = 0; i < this.paths.Length; i++)
                 {
                     paths[i] = this.paths[i].AsClosedPath();

--- a/src/SixLabors.Shapes/CubicBezierLineSegment.cs
+++ b/src/SixLabors.Shapes/CubicBezierLineSegment.cs
@@ -12,8 +12,8 @@ namespace SixLabors.Shapes
     /// <summary>
     /// Represents a line segment that contains a lists of control points that will be rendered as a cubic bezier curve
     /// </summary>
-    /// <seealso cref="SixLabors.Shapes.ILineSegment" />
-    public class CubicBezierLineSegment : ILineSegment
+    /// <seealso cref="ILineSegment" />
+    public sealed class CubicBezierLineSegment : ILineSegment
     {
         // code for this taken from <see href="http://devmag.org.za/2011/04/05/bzier-curves-a-tutorial/"/>
         private const float MinimumSqrDistance = 1.75f;
@@ -100,7 +100,7 @@ namespace SixLabors.Shapes
                 return this;
             }
 
-            PointF[] points = new PointF[this.controlPoints.Length];
+            var points = new PointF[this.controlPoints.Length];
             int i = 0;
             foreach (PointF p in this.controlPoints)
             {
@@ -119,7 +119,7 @@ namespace SixLabors.Shapes
 
         private static List<PointF> GetDrawingPoints(PointF[] controlPoints)
         {
-            List<PointF> drawingPoints = new List<PointF>();
+            var drawingPoints = new List<PointF>();
             int curveCount = (controlPoints.Length - 1) / 3;
 
             for (int curveIndex = 0; curveIndex < curveCount; curveIndex++)
@@ -140,7 +140,7 @@ namespace SixLabors.Shapes
 
         private static List<PointF> FindDrawingPoints(int curveIndex, PointF[] controlPoints)
         {
-            List<PointF> pointList = new List<PointF>();
+            var pointList = new List<PointF>();
 
             Vector2 left = CalculateBezierPoint(curveIndex, 0, controlPoints);
             Vector2 right = CalculateBezierPoint(curveIndex, 1, controlPoints);

--- a/src/SixLabors.Shapes/CubicBezierLineSegment.cs
+++ b/src/SixLabors.Shapes/CubicBezierLineSegment.cs
@@ -64,7 +64,7 @@ namespace SixLabors.Shapes
         /// <value>
         /// The end point.
         /// </value>
-        public PointF EndPoint { get; private set; }
+        public PointF EndPoint { get; }
 
         /// <summary>
         /// Returns the current <see cref="ILineSegment" /> a simple linear path.
@@ -90,14 +90,14 @@ namespace SixLabors.Shapes
                 return this;
             }
 
-            var points = new PointF[this.controlPoints.Length];
-            int i = 0;
-            foreach (PointF p in this.controlPoints)
+            var transformedPoints = new PointF[this.controlPoints.Length];
+
+            for (int i = 0; i < this.controlPoints.Length; i++)
             {
-                points[i++] = PointF.Transform(p, matrix);
+                transformedPoints[i] = PointF.Transform(this.controlPoints[i], matrix);
             }
 
-            return new CubicBezierLineSegment(points);
+            return new CubicBezierLineSegment(transformedPoints);
         }
 
         /// <summary>

--- a/src/SixLabors.Shapes/CubicBezierLineSegment.cs
+++ b/src/SixLabors.Shapes/CubicBezierLineSegment.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using SixLabors.Primitives;
 
@@ -29,10 +28,10 @@ namespace SixLabors.Shapes
         /// Initializes a new instance of the <see cref="CubicBezierLineSegment"/> class.
         /// </summary>
         /// <param name="points">The points.</param>
-        public CubicBezierLineSegment(IEnumerable<PointF> points)
+        public CubicBezierLineSegment(PointF[] points)
         {
-            Guard.NotNull(points, nameof(points));
-            this.controlPoints = points.ToArray();
+            this.controlPoints = points ?? throw new ArgumentNullException(nameof(points));
+
             Guard.MustBeGreaterThanOrEqualTo(this.controlPoints.Length, 4, nameof(points));
 
             int correctPointCount = (this.controlPoints.Length - 1) % 3;
@@ -49,22 +48,13 @@ namespace SixLabors.Shapes
         /// <summary>
         /// Initializes a new instance of the <see cref="CubicBezierLineSegment"/> class.
         /// </summary>
-        /// <param name="points">The points.</param>
-        public CubicBezierLineSegment(PointF[] points)
-            : this((IEnumerable<PointF>)points)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CubicBezierLineSegment"/> class.
-        /// </summary>
         /// <param name="start">The start.</param>
         /// <param name="controlPoint1">The control point1.</param>
         /// <param name="controlPoint2">The control point2.</param>
         /// <param name="end">The end.</param>
         /// <param name="additionalPoints">The additional points.</param>
         public CubicBezierLineSegment(PointF start, PointF controlPoint1, PointF controlPoint2, PointF end, params PointF[] additionalPoints)
-            : this(new[] { start, controlPoint1, controlPoint2, end }.Concat(additionalPoints))
+            : this(new[] { start, controlPoint1, controlPoint2, end }.Merge(additionalPoints))
         {
         }
 

--- a/src/SixLabors.Shapes/Helpers/Guard.cs
+++ b/src/SixLabors.Shapes/Helpers/Guard.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace SixLabors.Shapes
 {
@@ -26,47 +24,6 @@ namespace SixLabors.Shapes
             if (target is null)
             {
                 throw new ArgumentNullException(parameterName);
-            }
-        }
-
-        /// <summary>
-        /// Verifies, that the string method parameter with specified object value and message
-        /// is not null, not empty and does not contain only blanks and throws an exception
-        /// if the object is null.
-        /// </summary>
-        /// <param name="target">The target string, which should be checked against being null or empty.</param>
-        /// <param name="parameterName">Name of the parameter.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="target"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="target"/> is empty or contains only blanks.</exception>
-        public static void NotNullOrEmpty(string target, string parameterName)
-        {
-            if (target is null)
-            {
-                throw new ArgumentNullException(nameof(target));
-            }
-
-            if (string.IsNullOrWhiteSpace(target))
-            {
-                throw new ArgumentException("Value cannot be null or empty and cannot contain only blanks.", parameterName);
-            }
-        }
-
-        /// <summary>
-        /// Verifies, that the enumeration is not null and not empty.
-        /// </summary>
-        /// <typeparam name="T">The type of objects in the <paramref name="target"/></typeparam>
-        /// <param name="target">The target enumeration, which should be checked against being null or empty.</param>
-        /// <param name="parameterName">Name of the parameter.</param>
-        /// <param name="message">The error message, if any to add to the exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="target"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="target"/> is empty.</exception>
-        public static void NotNullOrEmpty<T>(IEnumerable<T> target, string parameterName)
-        {
-            NotNull(target, parameterName);
-
-            if (!target.Any())
-            {
-                throw new ArgumentException("Value cannot be empty.", parameterName);
             }
         }
 
@@ -170,48 +127,6 @@ namespace SixLabors.Shapes
             if (value.CompareTo(min) < 0 || value.CompareTo(max) > 0)
             {
                 throw new ArgumentOutOfRangeException(parameterName, $"Value must be greater than or equal to {min} and less than or equal to {max}.");
-            }
-        }
-
-        /// <summary>
-        /// Verifies, that the method parameter with specified target value is true
-        /// and throws an exception if it is found to be so.
-        /// </summary>
-        /// <param name="target">
-        /// The target value, which cannot be false.
-        /// </param>
-        /// <param name="parameterName">
-        /// The name of the parameter that is to be checked.
-        /// </param>
-        /// <param name="message">
-        /// The error message, if any to add to the exception.
-        /// </param>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="target"/> is false
-        /// </exception>
-        public static void IsTrue(bool target, string parameterName, string message)
-        {
-            if (!target)
-            {
-                throw new ArgumentException(message, parameterName);
-            }
-        }
-
-        /// <summary>
-        /// Verifies, that the method parameter with specified target value is false
-        /// and throws an exception if it is found to be so.
-        /// </summary>
-        /// <param name="target">The target value, which cannot be true.</param>
-        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
-        /// <param name="message">The error message, if any to add to the exception.</param>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="target"/> is true
-        /// </exception>
-        public static void IsFalse(bool target, string parameterName, string message)
-        {
-            if (target)
-            {
-                throw new ArgumentException(message, parameterName);
             }
         }
     }

--- a/src/SixLabors.Shapes/Helpers/Guard.cs
+++ b/src/SixLabors.Shapes/Helpers/Guard.cs
@@ -13,21 +13,6 @@ namespace SixLabors.Shapes
     internal static class Guard
     {
         /// <summary>
-        /// Verifies, that the method parameter with specified object value is not null
-        /// and throws an exception if it is found to be so.
-        /// </summary>
-        /// <param name="target">The target object, which cannot be null.</param>
-        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="target"/> is null</exception>
-        public static void NotNull(object target, string parameterName)
-        {
-            if (target is null)
-            {
-                throw new ArgumentNullException(parameterName);
-            }
-        }
-
-        /// <summary>
         /// Verifies that the specified value is less than a maximum value
         /// and throws an exception if it is not.
         /// </summary>

--- a/src/SixLabors.Shapes/Helpers/Guard.cs
+++ b/src/SixLabors.Shapes/Helpers/Guard.cs
@@ -20,17 +20,11 @@ namespace SixLabors.Shapes
         /// </summary>
         /// <param name="target">The target object, which cannot be null.</param>
         /// <param name="parameterName">The name of the parameter that is to be checked.</param>
-        /// <param name="message">The error message, if any to add to the exception.</param>
         /// <exception cref="ArgumentNullException"><paramref name="target"/> is null</exception>
-        public static void NotNull(object target, string parameterName, string message = "")
+        public static void NotNull(object target, string parameterName)
         {
-            if (target == null)
+            if (target is null)
             {
-                if (!string.IsNullOrWhiteSpace(message))
-                {
-                    throw new ArgumentNullException(parameterName, message);
-                }
-
                 throw new ArgumentNullException(parameterName);
             }
         }
@@ -42,20 +36,17 @@ namespace SixLabors.Shapes
         /// </summary>
         /// <param name="target">The target string, which should be checked against being null or empty.</param>
         /// <param name="parameterName">Name of the parameter.</param>
-        /// <param name="message">The error message, if any to add to the exception.</param>
         /// <exception cref="ArgumentNullException"><paramref name="target"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="target"/> is empty or contains only blanks.</exception>
-        public static void NotNullOrEmpty(string target, string parameterName, string message = "")
+        public static void NotNullOrEmpty(string target, string parameterName)
         {
-            NotNull(target, parameterName, message);
+            if (target is null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
 
             if (string.IsNullOrWhiteSpace(target))
             {
-                if (!string.IsNullOrWhiteSpace(message))
-                {
-                    throw new ArgumentException(message, parameterName);
-                }
-
                 throw new ArgumentException("Value cannot be null or empty and cannot contain only blanks.", parameterName);
             }
         }
@@ -69,17 +60,12 @@ namespace SixLabors.Shapes
         /// <param name="message">The error message, if any to add to the exception.</param>
         /// <exception cref="ArgumentNullException"><paramref name="target"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="target"/> is empty.</exception>
-        public static void NotNullOrEmpty<T>(IEnumerable<T> target, string parameterName, string message = "")
+        public static void NotNullOrEmpty<T>(IEnumerable<T> target, string parameterName)
         {
-            NotNull(target, parameterName, message);
+            NotNull(target, parameterName);
 
             if (!target.Any())
             {
-                if (!string.IsNullOrWhiteSpace(message))
-                {
-                    throw new ArgumentException(message, parameterName);
-                }
-
                 throw new ArgumentException("Value cannot be empty.", parameterName);
             }
         }

--- a/src/SixLabors.Shapes/InternalPath.cs
+++ b/src/SixLabors.Shapes/InternalPath.cs
@@ -113,10 +113,7 @@ namespace SixLabors.Shapes
         /// <value>
         /// The bounds.
         /// </value>
-        public RectangleF Bounds
-        {
-            get;
-        }
+        public RectangleF Bounds { get; }
 
         /// <summary>
         /// Gets the length.
@@ -138,7 +135,7 @@ namespace SixLabors.Shapes
         /// <returns>Returns the distance from the path</returns>
         public PointInfo DistanceFromPath(PointF point)
         {
-            PointInfoInternal internalInfo = default(PointInfoInternal);
+            PointInfoInternal internalInfo = default;
             internalInfo.DistanceSquared = float.MaxValue; // Set it to max so that CalculateShorterDistance can reduce it back down
 
             int polyCorners = this.points.Length;
@@ -191,7 +188,7 @@ namespace SixLabors.Shapes
 
             this.ClampPoints(ref start, ref end);
 
-            Segment target = new Segment(start, end);
+            var target = new Segment(start, end);
 
             int polyCorners = this.points.Length;
 
@@ -216,7 +213,7 @@ namespace SixLabors.Shapes
                 // iterate over all points and precalculate data about each, pre cacluating it relative orientation
                 for (int i = 0; i < polyCorners && count > 0; i++)
                 {
-                    Segment edge = this.points[i].Segment;
+                    ref Segment edge = ref this.points[i].Segment;
 
                     // shift all orientations along but one place and fill in the last one
                     Orientation pointOrientation = nextOrientation;
@@ -521,7 +518,7 @@ namespace SixLabors.Shapes
         /// <returns>
         /// The point on the line that it hit
         /// </returns>
-        private static Vector2 FindIntersection(Segment source, Segment target)
+        private static Vector2 FindIntersection(in Segment source, in Segment target)
         {
             Vector2 line1Start = source.Start;
             Vector2 line1End = source.End;
@@ -843,12 +840,12 @@ namespace SixLabors.Shapes
             public bool DoIntersect;
         }
 
-        private struct Segment
+        private readonly struct Segment
         {
-            public PointF Start;
-            public PointF End;
-            public PointF Min;
-            public PointF Max;
+            public readonly PointF Start;
+            public readonly PointF End;
+            public readonly PointF Min;
+            public readonly PointF Max;
 
             public Segment(PointF start, PointF end)
             {

--- a/src/SixLabors.Shapes/LinearLineSegment.cs
+++ b/src/SixLabors.Shapes/LinearLineSegment.cs
@@ -12,7 +12,7 @@ namespace SixLabors.Shapes
     /// Represents a series of control points that will be joined by straight lines
     /// </summary>
     /// <seealso cref="ILineSegment" />
-    public class LinearLineSegment : ILineSegment
+    public sealed class LinearLineSegment : ILineSegment
     {
         /// <summary>
         /// The collection of points.
@@ -89,7 +89,7 @@ namespace SixLabors.Shapes
                 return this;
             }
 
-            PointF[] points = new PointF[this.points.Length];
+            var points = new PointF[this.points.Length];
             int i = 0;
             foreach (PointF p in this.points)
             {

--- a/src/SixLabors.Shapes/LinearLineSegment.cs
+++ b/src/SixLabors.Shapes/LinearLineSegment.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -36,7 +37,7 @@ namespace SixLabors.Shapes
         /// <param name="point2">The point2.</param>
         /// <param name="additionalPoints">Additional points</param>
         public LinearLineSegment(PointF point1, PointF point2, params PointF[] additionalPoints)
-            : this(new[] { point1, point2 }.Concat(additionalPoints))
+            : this(new[] { point1, point2 }.Merge(additionalPoints))
         {
         }
 
@@ -44,11 +45,9 @@ namespace SixLabors.Shapes
         /// Initializes a new instance of the <see cref="LinearLineSegment"/> class.
         /// </summary>
         /// <param name="points">The points.</param>
-        public LinearLineSegment(IEnumerable<PointF> points)
+        public LinearLineSegment(PointF[] points)
         {
-            Guard.NotNull(points, nameof(points));
-
-            this.points = points.ToArray();
+            this.points = points ?? throw new ArgumentNullException(nameof(points));
 
             Guard.MustBeGreaterThanOrEqualTo(this.points.Length, 2, nameof(points));
 

--- a/src/SixLabors.Shapes/LinearLineSegment.cs
+++ b/src/SixLabors.Shapes/LinearLineSegment.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using SixLabors.Primitives;
 
@@ -60,7 +59,7 @@ namespace SixLabors.Shapes
         /// <value>
         /// The end point.
         /// </value>
-        public PointF EndPoint { get; private set; }
+        public PointF EndPoint { get; }
 
         /// <summary>
         /// Converts the <see cref="ILineSegment" /> into a simple linear path..
@@ -68,10 +67,7 @@ namespace SixLabors.Shapes
         /// <returns>
         /// Returns the current <see cref="ILineSegment" /> as simple linear path.
         /// </returns>
-        public IReadOnlyList<PointF> Flatten()
-        {
-            return this.points;
-        }
+        public IReadOnlyList<PointF> Flatten() => this.points;
 
         /// <summary>
         /// Transforms the current LineSegment using specified matrix.
@@ -88,14 +84,14 @@ namespace SixLabors.Shapes
                 return this;
             }
 
-            var points = new PointF[this.points.Length];
-            int i = 0;
-            foreach (PointF p in this.points)
+            var transformedPoints = new PointF[this.points.Length];
+
+            for (int i = 0; i < this.points.Length; i++)
             {
-                points[i++] = PointF.Transform(p, matrix);
+                transformedPoints[i] = PointF.Transform(this.points[i], matrix);
             }
 
-            return new LinearLineSegment(points);
+            return new LinearLineSegment(transformedPoints);
         }
 
         /// <summary>

--- a/src/SixLabors.Shapes/Outliner.cs
+++ b/src/SixLabors.Shapes/Outliner.cs
@@ -67,9 +67,9 @@ namespace SixLabors.Shapes
 
             IEnumerable<ISimplePath> paths = path.Flatten();
 
-            ClipperOffset offset = new ClipperOffset();
+            var offset = new ClipperOffset();
 
-            List<IntPoint> buffer = new List<IntPoint>(3);
+            var buffer = new List<IntPoint>(3);
             foreach (ISimplePath p in paths)
             {
                 bool online = !startOff;
@@ -160,14 +160,14 @@ namespace SixLabors.Shapes
         /// <returns>A new path representing the outline.</returns>
         public static IPath GenerateOutline(this IPath path, float width)
         {
-            ClipperOffset offset = new ClipperLib.ClipperOffset();
+            var offset = new ClipperOffset();
 
             // Pattern can be applied to the path by cutting it into segments
             IEnumerable<ISimplePath> paths = path.Flatten();
             foreach (ISimplePath p in paths)
             {
                 IReadOnlyList<PointF> vectors = p.Points;
-                List<IntPoint> points = new List<ClipperLib.IntPoint>(vectors.Count);
+                var points = new List<IntPoint>(vectors.Count);
                 foreach (Vector2 v in vectors)
                 {
                     points.Add(new IntPoint(v.X * ScalingFactor, v.Y * ScalingFactor));
@@ -183,9 +183,9 @@ namespace SixLabors.Shapes
 
         private static IPath ExecuteOutliner(float width, ClipperOffset offset)
         {
-            List<List<IntPoint>> tree = new List<List<IntPoint>>();
+            var tree = new List<List<IntPoint>>();
             offset.Execute(ref tree, width * ScalingFactor / 2);
-            List<Polygon> polygons = new List<Polygon>();
+            var polygons = new List<Polygon>();
             foreach (List<IntPoint> pt in tree)
             {
                 PointF[] points = pt.Select(p => new PointF(p.X / ScalingFactor, p.Y / ScalingFactor)).ToArray();

--- a/src/SixLabors.Shapes/Outliner.cs
+++ b/src/SixLabors.Shapes/Outliner.cs
@@ -60,7 +60,7 @@ namespace SixLabors.Shapes
         /// <returns>A new path representing the outline.</returns>
         public static IPath GenerateOutline(this IPath path, float width, ReadOnlySpan<float> pattern, bool startOff)
         {
-            if (pattern == null || pattern.Length < 2)
+            if (pattern.Length < 2)
             {
                 return path.GenerateOutline(width);
             }

--- a/src/SixLabors.Shapes/Path.cs
+++ b/src/SixLabors.Shapes/Path.cs
@@ -166,7 +166,7 @@ namespace SixLabors.Shapes
         /// </returns>
         public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
-            return this.InnerPath.FindIntersections(start, end, buffer);
+            return this.InnerPath.FindIntersections(start, end, buffer.AsSpan(offset));
         }
 
         /// <inheritdoc />

--- a/src/SixLabors.Shapes/Path.cs
+++ b/src/SixLabors.Shapes/Path.cs
@@ -21,9 +21,9 @@ namespace SixLabors.Shapes
         /// <summary>
         /// Initializes a new instance of the <see cref="Path"/> class.
         /// </summary>
-        /// <param name="segment">The segment.</param>
-        public Path(params ILineSegment[] segment)
-            : this((IEnumerable<ILineSegment>)segment)
+        /// <param name="segments">The segments.</param>
+        public Path(IEnumerable<ILineSegment> segments)
+            : this(segments?.ToArray())
         {
         }
 
@@ -40,9 +40,9 @@ namespace SixLabors.Shapes
         /// Initializes a new instance of the <see cref="Path"/> class.
         /// </summary>
         /// <param name="segments">The segments.</param>
-        public Path(IEnumerable<ILineSegment> segments)
+        public Path(params ILineSegment[] segments)
         {
-            this.lineSegments = segments.ToArray();
+            this.lineSegments = segments ?? throw new ArgumentNullException(nameof(segments));
         }
 
         /// <summary>
@@ -116,11 +116,11 @@ namespace SixLabors.Shapes
                 return this;
             }
 
-            ILineSegment[] segments = new ILineSegment[this.lineSegments.Length];
-            int i = 0;
-            foreach (ILineSegment s in this.LineSegments)
+            var segments = new ILineSegment[this.lineSegments.Length];
+
+            for (int i = 0; i < this.LineSegments.Count; i++)
             {
-                segments[i++] = s.Transform(matrix);
+                segments[i] = this.lineSegments[i].Transform(matrix);
             }
 
             return new Path(segments);
@@ -166,8 +166,7 @@ namespace SixLabors.Shapes
         /// </returns>
         public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
-            Span<PointF> subBuffer = buffer.AsSpan(offset);
-            return this.InnerPath.FindIntersections(start, end, subBuffer);
+            return this.InnerPath.FindIntersections(start, end, buffer);
         }
 
         /// <inheritdoc />

--- a/src/SixLabors.Shapes/PathBuilder.cs
+++ b/src/SixLabors.Shapes/PathBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -125,7 +126,10 @@ namespace SixLabors.Shapes
         /// <returns>The <see cref="PathBuilder"/></returns>
         public PathBuilder AddLines(IEnumerable<PointF> points)
         {
-            Guard.NotNull(points, nameof(points));
+            if (points is null)
+            {
+                throw new ArgumentNullException(nameof(points));
+            }
 
             this.AddLines(points.ToArray());
 

--- a/src/SixLabors.Shapes/PathCollection.cs
+++ b/src/SixLabors.Shapes/PathCollection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,7 +24,10 @@ namespace SixLabors.Shapes
         /// <param name="paths">The collection of paths</param>
         public PathCollection(IEnumerable<IPath> paths)
         {
-            Guard.NotNull(paths, nameof(paths));
+            if (paths is null)
+            {
+                throw new ArgumentNullException(nameof(paths));
+            }
 
             this.paths = paths as IPath[] ?? paths.ToArray();
 

--- a/src/SixLabors.Shapes/PathCollection.cs
+++ b/src/SixLabors.Shapes/PathCollection.cs
@@ -25,7 +25,8 @@ namespace SixLabors.Shapes
         {
             Guard.NotNull(paths, nameof(paths));
 
-            this.paths = paths.ToArray();
+            this.paths = paths as IPath[] ?? paths.ToArray();
+
             if (this.paths.Length == 0)
             {
                 this.Bounds = new RectangleF(0, 0, 0, 0);
@@ -60,7 +61,8 @@ namespace SixLabors.Shapes
         /// <inheritdoc />
         public IPathCollection Transform(Matrix3x2 matrix)
         {
-            IPath[] result = new IPath[this.paths.Length];
+            var result = new IPath[this.paths.Length];
+
             for (int i = 0; i < this.paths.Length && i < result.Length; i++)
             {
                 result[i] = this.paths[i].Transform(matrix);

--- a/src/SixLabors.Shapes/PathCollection.cs
+++ b/src/SixLabors.Shapes/PathCollection.cs
@@ -23,13 +23,17 @@ namespace SixLabors.Shapes
         /// </summary>
         /// <param name="paths">The collection of paths</param>
         public PathCollection(IEnumerable<IPath> paths)
+            : this(paths?.ToArray())
         {
-            if (paths is null)
-            {
-                throw new ArgumentNullException(nameof(paths));
-            }
+        }
 
-            this.paths = paths as IPath[] ?? paths.ToArray();
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PathCollection"/> class.
+        /// </summary>
+        /// <param name="paths">The collection of paths</param>
+        public PathCollection(params IPath[] paths)
+        {
+            this.paths = paths ?? throw new ArgumentNullException(nameof(paths));
 
             if (this.paths.Length == 0)
             {
@@ -45,15 +49,6 @@ namespace SixLabors.Shapes
 
                 this.Bounds = new RectangleF(minX, minY, maxX - minX, maxY - minY);
             }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PathCollection"/> class.
-        /// </summary>
-        /// <param name="paths">The collection of paths</param>
-        public PathCollection(params IPath[] paths)
-            : this((IEnumerable<IPath>)paths)
-        {
         }
 
         /// <inheritdoc />

--- a/src/SixLabors.Shapes/PolygonClipper/ClippablePath.cs
+++ b/src/SixLabors.Shapes/PolygonClipper/ClippablePath.cs
@@ -6,7 +6,7 @@ namespace SixLabors.Shapes.PolygonClipper
     /// <summary>
     /// Represents a shape and its type for when clipping is applies.
     /// </summary>
-    public struct ClippablePath
+    public readonly struct ClippablePath
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClippablePath" /> struct.
@@ -22,7 +22,7 @@ namespace SixLabors.Shapes.PolygonClipper
         /// <summary>
         /// Gets the path.
         /// </summary>
-        public IPath Path { get; private set; }
+        public IPath Path { get; }
 
         /// <summary>
         /// Gets the type.
@@ -30,6 +30,6 @@ namespace SixLabors.Shapes.PolygonClipper
         /// <value>
         /// The type.
         /// </value>
-        public ClippingType Type { get; private set; }
+        public ClippingType Type { get; }
     }
 }

--- a/src/SixLabors.Shapes/PolygonClipper/Clipper.cs
+++ b/src/SixLabors.Shapes/PolygonClipper/Clipper.cs
@@ -67,14 +67,9 @@ namespace SixLabors.Shapes.PolygonClipper
                     points[j] = new Vector2(p.X / ScalingFactor, p.Y / ScalingFactor);
                 }
 
-                if (results[i].IsOpen)
-                {
-                    shapes[i] = new Path(new LinearLineSegment(points));
-                }
-                else
-                {
-                    shapes[i] = new Polygon(new LinearLineSegment(points));
-                }
+                shapes[i] = results[i].IsOpen
+                    ? new Path(new LinearLineSegment(points))
+                    : new Polygon(new LinearLineSegment(points));
             }
 
             return shapes;

--- a/src/SixLabors.Shapes/PolygonClipper/Clipper.cs
+++ b/src/SixLabors.Shapes/PolygonClipper/Clipper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using ClipperLib;
@@ -16,7 +17,7 @@ namespace SixLabors.Shapes.PolygonClipper
         private const float ScalingFactor = 1000.0f;
 
         private readonly ClipperLib.Clipper innerClipper;
-        private object syncRoot = new object();
+        private readonly object syncRoot = new object();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Clipper"/> class.
@@ -24,16 +25,6 @@ namespace SixLabors.Shapes.PolygonClipper
         public Clipper()
         {
             this.innerClipper = new ClipperLib.Clipper();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Clipper"/> class.
-        /// </summary>
-        /// <param name="shapes">The shapes.</param>
-        public Clipper(IEnumerable<ClippablePath> shapes)
-            : this()
-        {
-            this.AddPaths(shapes);
         }
 
         /// <summary>
@@ -54,16 +45,18 @@ namespace SixLabors.Shapes.PolygonClipper
         /// </returns>
         public IEnumerable<IPath> GenerateClippedShapes()
         {
-            List<PolyNode> results = new List<PolyNode>();
+            var results = new List<PolyNode>();
             lock (this.syncRoot)
             {
                 this.innerClipper.Execute(ClipType.ctDifference, results);
             }
 
-            IPath[] shapes = new IPath[results.Count];
+            var shapes = new IPath[results.Count];
+
             for (int i = 0; i < results.Count; i++)
             {
-                PointF[] points = new PointF[results[i].Contour.Count];
+                var points = new PointF[results[i].Contour.Count];
+
                 for (int j = 0; j < results[i].Contour.Count; j++)
                 {
                     IntPoint p = results[i].Contour[j];
@@ -91,11 +84,17 @@ namespace SixLabors.Shapes.PolygonClipper
         /// Adds the paths.
         /// </summary>
         /// <param name="paths">The paths.</param>
-        public void AddPaths(IEnumerable<ClippablePath> paths)
+        public void AddPaths(ClippablePath[] paths)
         {
-            Guard.NotNull(paths, nameof(paths));
-            foreach (ClippablePath p in paths)
+            if (paths == null)
             {
+                throw new ArgumentNullException(nameof(paths));
+            }
+
+            for (int i = 0; i < paths.Length; i++)
+            {
+                ref ClippablePath p = ref paths[i];
+
                 this.AddPath(p.Path, p.Type);
             }
         }
@@ -107,7 +106,11 @@ namespace SixLabors.Shapes.PolygonClipper
         /// <param name="clippingType">The clipping type.</param>
         public void AddPaths(IEnumerable<IPath> paths, ClippingType clippingType)
         {
-            Guard.NotNull(paths, nameof(paths));
+            if (paths is null)
+            {
+                throw new ArgumentNullException(nameof(paths));
+            }
+
             foreach (IPath p in paths)
             {
                 this.AddPath(p, clippingType);
@@ -121,7 +124,11 @@ namespace SixLabors.Shapes.PolygonClipper
         /// <param name="clippingType">The clipping type.</param>
         public void AddPath(IPath path, ClippingType clippingType)
         {
-            Guard.NotNull(path, nameof(path));
+            if (path is null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
             foreach (ISimplePath p in path.Flatten())
             {
                 this.AddPath(p, clippingType);
@@ -138,7 +145,7 @@ namespace SixLabors.Shapes.PolygonClipper
         {
             IReadOnlyList<PointF> vectors = path.Points;
 
-            List<IntPoint> points = new List<ClipperLib.IntPoint>(vectors.Count);
+            var points = new List<IntPoint>(vectors.Count);
             foreach (PointF v in vectors)
             {
                 points.Add(new IntPoint(v.X * ScalingFactor, v.Y * ScalingFactor));

--- a/src/SixLabors.Shapes/RectangularPolygon.cs
+++ b/src/SixLabors.Shapes/RectangularPolygon.cs
@@ -11,7 +11,7 @@ namespace SixLabors.Shapes
     /// <summary>
     /// A way of optimizing drawing rectangles.
     /// </summary>
-    /// <seealso cref="SixLabors.Shapes.IPath" />
+    /// <seealso cref="IPath" />
     public class RectangularPolygon : IPath, ISimplePath
     {
         private readonly Vector2 topLeft;
@@ -168,7 +168,7 @@ namespace SixLabors.Shapes
         /// <value>
         /// The size.
         /// </value>
-        public SizeF Size { get; private set; }
+        public SizeF Size { get; }
 
         /// <summary>
         /// Gets the size.
@@ -459,9 +459,20 @@ namespace SixLabors.Shapes
         /// <returns>
         /// Returns the path as a closed path.
         /// </returns>
-        IPath IPath.AsClosedPath()
+        IPath IPath.AsClosedPath() => this;
+
+        /// <summary>
+        /// Returns whether the rectangles are equal.
+        /// </summary>
+        /// <param name="other">The other recentalge.</param>
+        /// <returns>Returns a value indicating if the rectangles are equal.</returns>
+        public bool Equals(RectangularPolygon other)
         {
-            return this;
+            return other != null &&
+                this.X == other.X &&
+                this.Y == other.Y &&
+                this.Height == other.Height &&
+                this.Width == other.Width;
         }
 
         /// <summary>
@@ -471,17 +482,7 @@ namespace SixLabors.Shapes
         /// <returns>Returns a value indicating if the rectangles are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj == null || this.GetType() != obj.GetType())
-            {
-                return false;
-            }
-
-            RectangularPolygon otherRectangle = (RectangularPolygon)obj;
-
-            return this.X == otherRectangle.X &&
-                this.Y == otherRectangle.Y &&
-                this.Height == otherRectangle.Height &&
-                this.Width == otherRectangle.Width;
+            return obj is RectangularPolygon other && this.Equals(other);
         }
 
         /// <summary>

--- a/src/SixLabors.Shapes/SixLabors.Shapes.csproj
+++ b/src/SixLabors.Shapes/SixLabors.Shapes.csproj
@@ -10,6 +10,7 @@
         <VersionPrefix Condition="$(packageversion) == ''">0.1.0-alpha1</VersionPrefix>
         <Authors>Six Labors and contributors</Authors>
         <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
+        <LangVersion>7.3</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AssemblyName>SixLabors.Shapes</AssemblyName>

--- a/src/SixLabors.Shapes/Star.cs
+++ b/src/SixLabors.Shapes/Star.cs
@@ -10,7 +10,7 @@ namespace SixLabors.Shapes
     /// <summary>
     /// A shape made up of a single path made up of one of more <see cref="ILineSegment"/>s
     /// </summary>
-    public class Star : Polygon
+    public sealed class Star : Polygon
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Star" /> class.
@@ -70,13 +70,13 @@ namespace SixLabors.Shapes
             Guard.MustBeGreaterThan(innerRadii, 0, nameof(innerRadii));
             Guard.MustBeGreaterThan(outerRadii, 0, nameof(outerRadii));
 
-            Vector2 distanceVectorInner = new Vector2(0, innerRadii);
-            Vector2 distanceVectorOuter = new Vector2(0, outerRadii);
+            var distanceVectorInner = new Vector2(0, innerRadii);
+            var distanceVectorOuter = new Vector2(0, outerRadii);
 
             int verticies = prongs * 2;
             float anglePerSegemnts = (float)((2 * Math.PI) / verticies);
             float current = angle;
-            PointF[] points = new PointF[verticies];
+            var points = new PointF[verticies];
             Vector2 distance = distanceVectorInner;
             for (int i = 0; i < verticies; i++)
             {

--- a/tests/SixLabors.Shapes.Benchmarks/SixLabors.Shapes.Benchmarks.csproj
+++ b/tests/SixLabors.Shapes.Benchmarks/SixLabors.Shapes.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SixLabors.Shapes.Tests/SixLabors.Shapes.Tests.csproj
+++ b/tests/SixLabors.Shapes.Tests/SixLabors.Shapes.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>SixLabors.Shapes.Tests</AssemblyName>
     <PackageId>SixLabors.Shapes.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -25,10 +25,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Moq" Version="4.8.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Update to .NETCORE2.1
- Eliminate unnecessary calls to ToArray()
- Seal classes to improve devirtualization
- Annotate readonly structs and access by reference
- Removes IEnumerable<> constructors on CubicBezier and LinearLineSegments to promote allocation free use (Breaking)
- Modernizes code styles (var when type is on RHS, ternary operators, expressions, and pattern matching)
- Throws exceptions inline to improve debugging (and reduce calls)